### PR TITLE
M1: Auth skeleton with DEV fallback

### DIFF
--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -11,7 +11,10 @@
   <properties><java.version>21</java.version></properties>
   <dependencies>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-security</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-oauth2-resource-server</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+    <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-test</artifactId><scope>test</scope></dependency>
   </dependencies>
   <build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId></plugin></plugins></build>
 </project>

--- a/apps/api/src/main/java/com/ligare/callcenter/Application.java
+++ b/apps/api/src/main/java/com/ligare/callcenter/Application.java
@@ -1,4 +1,5 @@
 package com.ligare.callcenter;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,4 +11,7 @@ public class Application {
 }
 
 @RestController
-class HealthController { @GetMapping("/health") String health(){ return "ok"; } }
+class HealthController {
+  @GetMapping("/health")
+  String health(){ return "ok"; }
+}

--- a/apps/api/src/main/java/com/ligare/callcenter/AuthController.java
+++ b/apps/api/src/main/java/com/ligare/callcenter/AuthController.java
@@ -1,0 +1,21 @@
+package com.ligare.callcenter;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  @GetMapping("/me")
+  public Map<String, Object> me(Authentication auth) {
+    return Map.of(
+      "user", auth.getName(),
+      "roles", auth.getAuthorities().stream().map(a -> a.getAuthority()).collect(Collectors.toList())
+    );
+  }
+}

--- a/apps/api/src/main/java/com/ligare/callcenter/SecurityConfig.java
+++ b/apps/api/src/main/java/com/ligare/callcenter/SecurityConfig.java
@@ -1,0 +1,80 @@
+package com.ligare.callcenter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  SecurityFilterChain securityFilterChain(HttpSecurity http, DevFallbackAuthFilter devFilter, @Value("${app.auth.dev-fallback:false}") boolean devFallback) throws Exception {
+    http
+      .csrf(csrf -> csrf.disable())
+      .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers("/health").permitAll()
+        .requestMatchers(HttpMethod.GET, "/api/auth/me").authenticated()
+        .anyRequest().authenticated()
+      )
+      .addFilterBefore(devFilter, UsernamePasswordAuthenticationFilter.class);
+
+    if (!devFallback) {
+      http.oauth2ResourceServer(oauth -> oauth.jwt(Customizer.withDefaults()));
+    }
+
+    return http.build();
+  }
+
+  @Bean
+  JwtAuthenticationConverter jwtAuthenticationConverter() {
+    return new JwtAuthenticationConverter();
+  }
+
+  @Bean
+  DevFallbackAuthFilter devFallbackAuthFilter() {
+    return new DevFallbackAuthFilter();
+  }
+}
+
+class DevFallbackAuthFilter extends OncePerRequestFilter {
+
+  @Value("${app.auth.dev-fallback:false}")
+  private boolean devFallback;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (devFallback && SecurityContextHolder.getContext().getAuthentication() == null) {
+      String user = request.getHeader("X-Dev-User");
+      String role = request.getHeader("X-Dev-Role");
+      if (user != null && !user.isBlank()) {
+        String normalizedRole = (role == null || role.isBlank()) ? "AGENT" : role.toUpperCase();
+        var auth = new UsernamePasswordAuthenticationToken(
+            user,
+            "N/A",
+            List.of(new SimpleGrantedAuthority("ROLE_" + normalizedRole))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+      }
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/apps/api/src/test/java/com/ligare/callcenter/AuthControllerTest.java
+++ b/apps/api/src/test/java/com/ligare/callcenter/AuthControllerTest.java
@@ -1,0 +1,35 @@
+package com.ligare.callcenter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"app.auth.dev-fallback=true"})
+@AutoConfigureMockMvc
+class AuthControllerTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @Test
+  void rejectsWithoutDevHeaders() throws Exception {
+    mvc.perform(get("/api/auth/me"))
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void returnsUserWhenDevHeadersProvided() throws Exception {
+    mvc.perform(get("/api/auth/me")
+      .header("X-Dev-User", "dev@ligare.com")
+      .header("X-Dev-Role", "SUPERVISOR"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.user").value("dev@ligare.com"))
+      .andExpect(jsonPath("$.roles[0]").value("ROLE_SUPERVISOR"));
+  }
+}


### PR DESCRIPTION
Closes #3\n\nAdds Spring Security auth baseline with OAuth2 resource server path plus DEV fallback header auth mode () for local development continuity without OIDC secrets. Includes endpoint  and tests.