### PR TITLE
M1: Server-side RBAC middleware and tests

### DIFF
--- a/apps/api/src/main/java/com/ligare/callcenter/RbacProbeController.java
+++ b/apps/api/src/main/java/com/ligare/callcenter/RbacProbeController.java
@@ -1,0 +1,31 @@
+package com.ligare.callcenter;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class RbacProbeController {
+
+  @GetMapping("/admin/ping")
+  public Map<String, String> adminPing() {
+    return Map.of("scope", "admin");
+  }
+
+  @GetMapping("/supervisor/ping")
+  public Map<String, String> supervisorPing() {
+    return Map.of("scope", "supervisor");
+  }
+
+  @GetMapping("/agent/ping")
+  public Map<String, String> agentPing() {
+    return Map.of("scope", "agent");
+  }
+
+  @GetMapping("/auditor/ping")
+  public Map<String, String> auditorPing() {
+    return Map.of("scope", "auditor");
+  }
+}

--- a/apps/api/src/main/java/com/ligare/callcenter/SecurityConfig.java
+++ b/apps/api/src/main/java/com/ligare/callcenter/SecurityConfig.java
@@ -32,6 +32,10 @@ public class SecurityConfig {
       .authorizeHttpRequests(auth -> auth
         .requestMatchers("/health").permitAll()
         .requestMatchers(HttpMethod.GET, "/api/auth/me").authenticated()
+        .requestMatchers("/api/admin/**").hasAnyRole("OWNER", "ADMIN")
+        .requestMatchers("/api/supervisor/**").hasAnyRole("OWNER", "ADMIN", "SUPERVISOR")
+        .requestMatchers("/api/agent/**").hasAnyRole("OWNER", "ADMIN", "SUPERVISOR", "AGENT")
+        .requestMatchers("/api/auditor/**").hasAnyRole("OWNER", "ADMIN", "AUDITOR")
         .anyRequest().authenticated()
       )
       .addFilterBefore(devFilter, UsernamePasswordAuthenticationFilter.class);

--- a/apps/api/src/test/java/com/ligare/callcenter/RbacMatrixTest.java
+++ b/apps/api/src/test/java/com/ligare/callcenter/RbacMatrixTest.java
@@ -1,0 +1,47 @@
+package com.ligare.callcenter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {"app.auth.dev-fallback=true"})
+@AutoConfigureMockMvc
+class RbacMatrixTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @Test
+  void agentCannotAccessAdminRoute() throws Exception {
+    mvc.perform(get("/api/admin/ping")
+        .header("X-Dev-User", "agent@ligare.com")
+        .header("X-Dev-Role", "AGENT"))
+      .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void adminCanAccessAdminRoute() throws Exception {
+    mvc.perform(get("/api/admin/ping")
+        .header("X-Dev-User", "admin@ligare.com")
+        .header("X-Dev-Role", "ADMIN"))
+      .andExpect(status().isOk());
+  }
+
+  @Test
+  void auditorCanAccessAuditorRouteOnly() throws Exception {
+    mvc.perform(get("/api/auditor/ping")
+        .header("X-Dev-User", "auditor@ligare.com")
+        .header("X-Dev-Role", "AUDITOR"))
+      .andExpect(status().isOk());
+
+    mvc.perform(get("/api/admin/ping")
+        .header("X-Dev-User", "auditor@ligare.com")
+        .header("X-Dev-Role", "AUDITOR"))
+      .andExpect(status().isForbidden());
+  }
+}


### PR DESCRIPTION
Closes #4\n\nImplements role-based route enforcement for admin/supervisor/agent/auditor API namespaces and adds RBAC matrix tests.