### PR TITLE
M2: DB schema and migration baseline

### DIFF
--- a/apps/api/pom.xml
+++ b/apps/api/pom.xml
@@ -13,8 +13,12 @@
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-security</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-oauth2-resource-server</artifactId></dependency>
+    <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-jdbc</artifactId></dependency>
+    <dependency><groupId>org.flywaydb</groupId><artifactId>flyway-core</artifactId></dependency>
+    <dependency><groupId>org.postgresql</groupId><artifactId>postgresql</artifactId><scope>runtime</scope></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
     <dependency><groupId>org.springframework.security</groupId><artifactId>spring-security-test</artifactId><scope>test</scope></dependency>
+    <dependency><groupId>com.h2database</groupId><artifactId>h2</artifactId><scope>test</scope></dependency>
   </dependencies>
   <build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId></plugin></plugins></build>
 </project>

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5433/ligare_call_center}
+    username: ${DB_USER:ligare}
+    password: ${DB_PASSWORD:ligare}
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+app:
+  auth:
+    dev-fallback: ${DEV_FALLBACK_AUTH:true}

--- a/apps/api/src/main/resources/db/migration/V1__init_schema.sql
+++ b/apps/api/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,65 @@
+CREATE TABLE IF NOT EXISTS users (
+  id BIGSERIAL PRIMARY KEY,
+  google_sub TEXT,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  role TEXT NOT NULL,
+  team TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+  id BIGSERIAL PRIMARY KEY,
+  team TEXT NOT NULL,
+  name TEXT NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS priorities (
+  id BIGSERIAL PRIMARY KEY,
+  team TEXT NOT NULL,
+  name TEXT NOT NULL,
+  sla_minutes INTEGER NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS calls (
+  id BIGSERIAL PRIMARY KEY,
+  team TEXT NOT NULL,
+  status TEXT NOT NULL,
+  category_id BIGINT REFERENCES categories(id),
+  priority BIGINT REFERENCES priorities(id),
+  assigned_to BIGINT REFERENCES users(id),
+  start_time TIMESTAMPTZ,
+  end_time TIMESTAMPTZ,
+  aht_seconds INTEGER,
+  caller_name TEXT,
+  callback_number TEXT,
+  patient_name TEXT,
+  patient_dob DATE,
+  reason TEXT,
+  disposition_text TEXT,
+  tags TEXT[] NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS call_events (
+  id BIGSERIAL PRIMARY KEY,
+  call_id BIGINT NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  payload_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by BIGINT REFERENCES users(id)
+);
+
+CREATE TABLE IF NOT EXISTS kpi_daily_rollup (
+  id BIGSERIAL PRIMARY KEY,
+  date DATE NOT NULL,
+  team TEXT NOT NULL,
+  metrics_json JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(date, team)
+);

--- a/apps/api/src/test/java/com/ligare/callcenter/MigrationSmokeTest.java
+++ b/apps/api/src/test/java/com/ligare/callcenter/MigrationSmokeTest.java
@@ -1,0 +1,12 @@
+package com.ligare.callcenter;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class MigrationSmokeTest {
+  @Test
+  void migrationFileExists() {
+    assertNotNull(getClass().getResource("/db/migration/V1__init_schema.sql"));
+  }
+}

--- a/apps/api/src/test/resources/application.properties
+++ b/apps/api/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.flyway.enabled=false
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=


### PR DESCRIPTION
Closes #5\n\nAdds Flyway + JDBC setup and initial PostgreSQL schema migration for users, calls, call_events, categories, priorities, and kpi_daily_rollup.